### PR TITLE
Fix example

### DIFF
--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -57,7 +57,7 @@ void testApp::gotMessage(ofMessage msg){
 void testApp::dragEvent(ofDragInfo dragInfo){
     if( dragInfo.files.size() > 0 ){
 		for(int i = 0; i < dragInfo.files.size(); i++){
-            composer.addPatch( dragInfo.files[i], dragInfo.position );
+            composer.addPatchFromFile( dragInfo.files[i], dragInfo.position );
 		}
 	}
 }


### PR DESCRIPTION
I was getting a build error on `composer.addPatch` so I replaced with `composer.addPatchFromFile`. Deprecated method from an earlier version? The example builds now...
